### PR TITLE
Failure callback url, fallover error page and locked trust page

### DIFF
--- a/app/controllers/BeforeYouContinueController.scala
+++ b/app/controllers/BeforeYouContinueController.scala
@@ -61,8 +61,8 @@ class BeforeYouContinueController @Inject()(
       } yield {
 
         relationship.check(request.internalId, utr) { _ =>
-          val successRedirect = routes.BeforeYouContinueController.onPageLoad().absoluteURL
-          val failureRedirect = routes.UnauthorisedController.onPageLoad().absoluteURL
+          val successRedirect = routes.IvSuccessController.onPageLoad().absoluteURL
+          val failureRedirect = routes.IVFailureController.onTrustIVFailure().absoluteURL
 
           val host = s"${config.relationshipEstablishmentJourneyService}/trusts-relationship-establishment/relationships/$utr"
 

--- a/app/controllers/FallbackFailureController.scala
+++ b/app/controllers/FallbackFailureController.scala
@@ -16,28 +16,19 @@
 
 package controllers
 
-import controllers.actions.IdentifierAction
+import handlers.ErrorHandler
 import javax.inject.Inject
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.play.bootstrap.controller.FrontendBaseController
-import views.html.UnauthorisedView
 
-import scala.concurrent.Future
-
-class IVFailureController @Inject()(
+class FallbackFailureController @Inject()(
                                         val controllerComponents: MessagesControllerComponents,
-                                        unauthorisedView: UnauthorisedView,
-                                        identify: IdentifierAction
+                                        errorHandler: ErrorHandler
                                       ) extends FrontendBaseController with I18nSupport {
 
-  def onTrustIVFailure: Action[AnyContent] = identify.async {
+  def onPageLoad: Action[AnyContent] = Action {
     implicit request =>
-      Future.successful(Redirect(routes.IVFailureController.trustLocked()))
-  }
-
-  def trustLocked : Action[AnyContent] = identify.async {
-    implicit request =>
-      Future.successful(Ok(unauthorisedView()))
+      InternalServerError(errorHandler.internalServerErrorTemplate)
   }
 }

--- a/app/controllers/IVFailureController.scala
+++ b/app/controllers/IVFailureController.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import controllers.actions.IdentifierAction
+import javax.inject.Inject
+import play.api.i18n.I18nSupport
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.play.bootstrap.controller.FrontendBaseController
+import views.html.UnauthorisedView
+
+import scala.concurrent.Future
+
+class IVFailureController @Inject()(
+                                        val controllerComponents: MessagesControllerComponents,
+                                        unauthorisedView: UnauthorisedView,
+                                        identify: IdentifierAction
+                                      ) extends FrontendBaseController with I18nSupport {
+
+  def onTrustIVFailure: Action[AnyContent] = identify.async {
+    implicit request =>
+      println(s"calling on trust iv failure")
+      Future.successful(Redirect(routes.IVFailureController.trustLocked()))
+  }
+
+  def trustLocked : Action[AnyContent] = identify.async {
+    implicit request =>
+      println(s"calling trust locked")
+      Future.successful(Ok(unauthorisedView()))
+  }
+}

--- a/app/views/GovukWrapper.scala.html
+++ b/app/views/GovukWrapper.scala.html
@@ -56,7 +56,7 @@
       navTitle = Some(messages("site.service_name")),
       navTitleLink = None,
       showBetaLink = false,
-      navLinks = Some(headerNavLinks))
+      navLinks = None)
 }
 
 @afterHeader = {}

--- a/app/views/TrustLocked.scala.html
+++ b/app/views/TrustLocked.scala.html
@@ -1,0 +1,33 @@
+@*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this(
+    main_template: MainTemplate
+)
+
+@(utr: String)(implicit request: Request[_], messages: Messages)
+
+@main_template(
+    title = messages("locked.title")
+    ) {
+
+    <span class="govuk-caption-xl">@messages("locked.subheading", utr)</span>
+    @components.heading("locked.heading", headingSize = "heading-large govuk-fieldset__heading")
+
+    <p>@messages("locked.p1")</p>
+    <p>@messages("locked.p2")</p>
+<p>@messages("locked.p3") <a target="_blank" href="https://www.gov.uk/government/organisations/hm-revenue-customs/contact/trusts">@messages("locked.link")</a>.</p>
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -2,6 +2,10 @@
 
 GET        /                                            controllers.IndexController.onPageLoad
 
+GET        /callback-failure                                     controllers.IVFailureController.onTrustIVFailure
+
+GET        /locked                                      controllers.IVFailureController.trustLocked
+
 GET        /assets/*file                                controllers.Assets.versioned(path="/public", file: Asset)
 
 GET        /language/:lang                              controllers.LanguageSwitchController.switchToLanguage(lang: String)
@@ -23,7 +27,3 @@ POST       /change/managed-by-agent                        controllers.IsAgentMa
 GET        /claimed                                     controllers.IvSuccessController.onPageLoad
 
 GET        /:utr                                        controllers.SaveUTRController.save(utr: String)
-
-GET        /failure                                     controllers.IVFailureController.onTrustIVFailure
-
-GET        /locked                                      controllers.IVFailureController.trustLocked

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -21,4 +21,9 @@ GET        /change/managed-by-agent                        controllers.IsAgentMa
 POST       /change/managed-by-agent                        controllers.IsAgentManagingTrustController.onSubmit(mode: Mode = CheckMode)
 
 GET        /claimed                                     controllers.IvSuccessController.onPageLoad
+
 GET        /:utr                                        controllers.SaveUTRController.save(utr: String)
+
+GET        /failure                                     controllers.IVFailureController.onTrustIVFailure
+
+GET        /locked                                      controllers.IVFailureController.trustLocked

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -2,9 +2,13 @@
 
 GET        /                                            controllers.IndexController.onPageLoad
 
-GET        /callback-failure                                     controllers.IVFailureController.onTrustIVFailure
+GET        /callback-failure                            controllers.IVFailureController.onTrustIVFailure
 
 GET        /locked                                      controllers.IVFailureController.trustLocked
+
+GET        /something-went-wrong                        controllers.FallbackFailureController.onPageLoad
+
+GET        /claimed                                     controllers.IvSuccessController.onPageLoad
 
 GET        /assets/*file                                controllers.Assets.versioned(path="/public", file: Asset)
 

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -76,3 +76,11 @@ beforeYouContinue.p2 = Your answers must match the details provided to HMRC when
 beforeYouContinue.p3 = Do not enter any other details when answering these questions, even if someone from the trust wrote to HMRC to change them.
 beforeYouContinue.p4 = If you need help using the service
 beforeYouContinue.a = contact the trusts helpline (opens in a new window or tab)
+
+locked.title = Sorry, you cannot access this trust
+locked.heading = Sorry, you cannot access this trust
+locked.p1 = You have not passed the security questions asked by HMRC.
+locked.p2 = Try again in 30 minutes.
+locked.p3 = If you need help with the service contact the
+locked.link = trusts helpline (opens in a new window or tab)
+locked.subheading = This trust’s UTR: {0}

--- a/test/controllers/FallbackFailureControllerSpec.scala
+++ b/test/controllers/FallbackFailureControllerSpec.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import base.SpecBase
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+
+class FallbackFailureControllerSpec extends SpecBase {
+
+  def onFailureRoute = routes.FallbackFailureController.onPageLoad().url
+
+  "FallbackFailure Controller" must {
+
+    "render internal server error view" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      val request = FakeRequest(GET, onFailureRoute)
+
+      val result = route(application, request).value
+
+      status(result) mustEqual INTERNAL_SERVER_ERROR
+
+      application.stop()
+    }
+
+  }
+}

--- a/test/controllers/IvFailureControllerSpec.scala
+++ b/test/controllers/IvFailureControllerSpec.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import base.SpecBase
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+
+class IvFailureControllerSpec extends SpecBase {
+
+//  {"journeyId":"47a8a543-6961-4221-86e8-d22e2c3c91de","relationship":{"relationshipName":"Trusts","businessKeys":[{"name":"utr","value":"3000000001"}],"credId":"987459879458"},"errorKey":"TRUST_LOCKED"}
+
+  def onIVFailureRoute = routes.IVFailureController.onTrustIVFailure().url
+
+  "IvFailure Controller" must {
+
+    "redirect to trust locked page when user fails Trusts IV after multiple attempts" in {
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      val request = FakeRequest(GET, onIVFailureRoute)
+        .withHeaders(
+          ("JourneyFailure", "http://localhost:9662/relationship-establishment/journey-failure/47a8a543-6961-4221-86e8-d22e2c3c91de")
+        )
+
+      val result = route(application, request).value
+
+      status(result) mustEqual SEE_OTHER
+
+      redirectLocation(result).value mustBe routes.IVFailureController.trustLocked().url
+
+      application.stop()
+    }
+
+  }
+}

--- a/test/controllers/IvFailureControllerSpec.scala
+++ b/test/controllers/IvFailureControllerSpec.scala
@@ -40,7 +40,7 @@ class IvFailureControllerSpec extends SpecBase {
 
       status(result) mustEqual SEE_OTHER
 
-      redirectLocation(result).value mustBe routes.IVFailureController.trustLocked().url
+      redirectLocation(result).value mustEqual routes.IVFailureController.trustLocked().url
 
       application.stop()
     }

--- a/test/controllers/IvFailureControllerSpec.scala
+++ b/test/controllers/IvFailureControllerSpec.scala
@@ -29,6 +29,7 @@ class IvFailureControllerSpec extends SpecBase {
   "IvFailure Controller" must {
 
     "redirect to trust locked page when user fails Trusts IV after multiple attempts" in {
+
       val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
 
       val request = FakeRequest(GET, onIVFailureRoute)

--- a/test/controllers/IvFailureControllerSpec.scala
+++ b/test/controllers/IvFailureControllerSpec.scala
@@ -17,6 +17,7 @@
 package controllers
 
 import base.SpecBase
+import pages.UtrPage
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 
@@ -24,26 +25,52 @@ class IvFailureControllerSpec extends SpecBase {
 
 //  {"journeyId":"47a8a543-6961-4221-86e8-d22e2c3c91de","relationship":{"relationshipName":"Trusts","businessKeys":[{"name":"utr","value":"3000000001"}],"credId":"987459879458"},"errorKey":"TRUST_LOCKED"}
 
-  def onIVFailureRoute = routes.IVFailureController.onTrustIVFailure().url
-
   "IvFailure Controller" must {
 
-    "redirect to trust locked page when user fails Trusts IV after multiple attempts" in {
+    "callback-failure route" when {
 
-      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+      "redirect to trust locked page when user fails Trusts IV after multiple attempts" in {
 
-      val request = FakeRequest(GET, onIVFailureRoute)
-        .withHeaders(
-          ("JourneyFailure", "http://localhost:9662/relationship-establishment/journey-failure/47a8a543-6961-4221-86e8-d22e2c3c91de")
-        )
+        val onIVFailureRoute = routes.IVFailureController.onTrustIVFailure().url
 
-      val result = route(application, request).value
+        val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
 
-      status(result) mustEqual SEE_OTHER
+        val request = FakeRequest(GET, onIVFailureRoute)
+          .withHeaders(
+            ("JourneyFailure", "http://localhost:9662/relationship-establishment/journey-failure/47a8a543-6961-4221-86e8-d22e2c3c91de")
+          )
 
-      redirectLocation(result).value mustEqual routes.IVFailureController.trustLocked().url
+        val result = route(application, request).value
 
-      application.stop()
+        status(result) mustEqual SEE_OTHER
+
+        redirectLocation(result).value mustEqual routes.IVFailureController.trustLocked().url
+
+        application.stop()
+      }
+    }
+
+    "locked route" when {
+
+      "return OK and the correct view for a GET for locked route" in {
+
+        val onLockedRoute = routes.IVFailureController.trustLocked().url
+
+        val answers = emptyUserAnswers
+          .set(UtrPage, "3000000001").success.value
+
+        val application = applicationBuilder(userAnswers = Some(answers)).build()
+
+        val request = FakeRequest(GET, onLockedRoute)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual OK
+
+        contentAsString(result) must include("Sorry, you cannot access this trust")
+
+        application.stop()
+      }
     }
 
   }


### PR DESCRIPTION
Implementing the correct success and failure urls to redirect when trust IV passes/fails.
Adding a fallback failure url of `claim-a-trust/something-went-wrong`.
