### PR TITLE
Fixing query parameter name to align with IV change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.metals/
 .cache
 /.classpath
 db

--- a/app/connectors/RelationshipEstablishmentConnector.scala
+++ b/app/connectors/RelationshipEstablishmentConnector.scala
@@ -26,8 +26,8 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class RelationshipEstablishmentConnector @Inject()(http: HttpClient, config : FrontendAppConfig) {
 
-  def journeyId(journeyFailure: String)(implicit hc : HeaderCarrier, ec : ExecutionContext): Future[JsValue] = {
-    val url = s"${config.relationshipEstablishmentUrl}/journey-failure/$journeyFailure"
+  def journeyId(id: String)(implicit hc : HeaderCarrier, ec : ExecutionContext): Future[JsValue] = {
+    val url = s"${config.relationshipEstablishmentUrl}/journey-failure/$id"
 
     http.GET[JsValue](url)
   }

--- a/test/controllers/IvFailureControllerSpec.scala
+++ b/test/controllers/IvFailureControllerSpec.scala
@@ -55,6 +55,27 @@ class IvFailureControllerSpec extends SpecBase {
 
     "callback-failure route" when {
 
+      "redirect to IV FallbackFailure when no journeyId is provided" in {
+        val fakeNavigator = new FakeNavigator(Call("GET", "/foo"))
+
+        val application = applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(bind[RelationshipEstablishmentConnector].toInstance(connector))
+          .overrides(bind[Navigator].toInstance(fakeNavigator))
+          .build()
+
+        val onIvFailureRoute = routes.IvFailureController.onTrustIvFailure().url
+
+        val request = FakeRequest(GET, s"$onIvFailureRoute")
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+
+        redirectLocation(result).value mustEqual routes.FallbackFailureController.onPageLoad().url
+
+        application.stop()
+      }
+
       "redirect to trust locked page when user fails Trusts IV after multiple attempts" in {
 
         val jsonWithErrorKey = Json.parse(
@@ -77,7 +98,7 @@ class IvFailureControllerSpec extends SpecBase {
         when(connector.journeyId(any[String])(any(), any()))
           .thenReturn(Future.successful(jsonWithErrorKey))
 
-        val request = FakeRequest(GET, onIvFailureRoute)
+        val request = FakeRequest(GET, s"$onIvFailureRoute?journeyId=47a8a543-6961-4221-86e8-d22e2c3c91de")
 
         val result = route(application, request).value
 
@@ -88,7 +109,7 @@ class IvFailureControllerSpec extends SpecBase {
         application.stop()
       }
 
-      "redirect to trust utr not found page when the utr isnt found" in {
+      "redirect to trust utr not found page when the utr isn't found" in {
 
         val jsonWithErrorKey = Json.parse(
           """
@@ -109,7 +130,7 @@ class IvFailureControllerSpec extends SpecBase {
 
         val onIvFailureRoute = routes.IvFailureController.onTrustIvFailure().url
 
-        val request = FakeRequest(GET, s"$onIvFailureRoute?journeyFailure=47a8a543-6961-4221-86e8-d22e2c3c91de")
+        val request = FakeRequest(GET, s"$onIvFailureRoute?journeyId=47a8a543-6961-4221-86e8-d22e2c3c91de")
 
         val result = route(application, request).value
 
@@ -141,7 +162,7 @@ class IvFailureControllerSpec extends SpecBase {
 
         val onIvFailureRoute = routes.IvFailureController.onTrustIvFailure().url
 
-        val request = FakeRequest(GET, s"$onIvFailureRoute?journeyFailure=47a8a543-6961-4221-86e8-d22e2c3c91de")
+        val request = FakeRequest(GET, s"$onIvFailureRoute?journeyId=47a8a543-6961-4221-86e8-d22e2c3c91de")
 
         val result = route(application, request).value
 


### PR DESCRIPTION
- Query parameter is now called JourneyId rather than JourneyFailure